### PR TITLE
Fix to allow full usage of a custom sources.yaml.

### DIFF
--- a/pybase16_builder/updater.py
+++ b/pybase16_builder/updater.py
@@ -74,14 +74,14 @@ def update(custom_sources=False, verbose=False):
         if not custom_sources:
             print("Creating sources.yaml…")
             write_sources_file()
-            print("Cloning sources…")
-            sources_file = rel_to_cwd("sources.yaml")
-            r = event_loop.run_until_complete(
-                git_clone_scheduler(
-                    sources_file, rel_to_cwd("sources"), verbose=verbose
-                )
+        print("Cloning sources…")
+        sources_file = rel_to_cwd("sources.yaml")
+        r = event_loop.run_until_complete(
+            git_clone_scheduler(
+                sources_file, rel_to_cwd("sources"), verbose=verbose
             )
-            results.append(r)
+        )
+        results.append(r)
 
         print("Cloning templates…")
         r = event_loop.run_until_complete(


### PR DESCRIPTION
I created my own scheme repository, with additional custom schemes not yet merged into the main base16 schemes repo, and updated my `sources.yaml` as follows:

```
schemes: https://github.com/lainproliant/base16-schemes-source.git
templates: https://github.com/chriskempson/base16-templates-source.git
```

Unfortunately, this was causing the `pybase16-update` script to skip the step of actually cloning all of the schemes (or templates) listed from the sources.  I fixed the indentation such that this behavior is no longer conditional on `not custom_sources`.

If this doesn't fall in line with the intended usage of pybase16, please feel free to reject this MR.

Thanks,

Lain
