### PR TITLE
Fix gbk encoding error and use `git pull` instead of `shutil.rmtree` to speed up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ templates
 sources.yaml
 .tags
 .cache
+.vscode/

--- a/pybase16_builder/builder.py
+++ b/pybase16_builder/builder.py
@@ -156,7 +156,7 @@ async def build_single(scheme_file, job_options):
                 verb_msg("File {} exists and will be overwritten.".format(build_path))
                 warn = True
 
-            async with aiofiles.open(build_path, "w") as file_:
+            async with aiofiles.open(build_path, "w", encoding="utf8") as file_:
                 file_content = pystache.render(sub["parsed"], scheme)
                 await file_.write(file_content)
 

--- a/pybase16_builder/shared.py
+++ b/pybase16_builder/shared.py
@@ -45,7 +45,7 @@ def get_yaml_dict(yaml_file):
     """Return a yaml_dict from reading yaml_file. If yaml_file is empty or
     doesn't exist, return an empty dict instead."""
     try:
-        with open(yaml_file, "r") as file_:
+        with open(yaml_file, "r", encoding="utf8") as file_:
             yaml_dict = yaml.safe_load(file_.read()) or {}
         return yaml_dict
     except FileNotFoundError:

--- a/pybase16_builder/updater.py
+++ b/pybase16_builder/updater.py
@@ -26,7 +26,6 @@ async def git_clone(git_url, path, verbose=False):
     proc_env = os.environ.copy()
     proc_env["GIT_TERMINAL_PROMPT"] = "0"
     if os.path.exists(os.path.join(path, ".git")):
-        # get rid of local repo if it already exists
         _tmp = os.getcwd()
         os.chdir(path)
         git_proc = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
## gbk encoding error
Here's the way to reproduce the issue.
```pwsh
PS C:\Users\90895\src\base16-builder-python> pybase16.exe build -t style -s danqing -v
Error:
C:\Users\90895\src\base16-builder-python\schemes\danqing\danqing.yaml: 'gbk' codec can't decode byte 0xa0 in position 211: illegal multibyte sequence
Finished building process.
```
This is because the `danying.yaml` contains Chinese comments:
```yaml
scheme: "DanQing"
author: "Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)"
base00: "2d302f" # ----
base01: "434846" # ---
base02: "5a605d" # --
base03: "9da8a3" # -
base04: "cad8d2" # +
base05: "e0f0eF" # ++ 素
base06: "ecf6f2" # +++
base07: "fcfefd" # ++++
base08: "F9906F" # red 酡颜
base09: "B38A61" # orange 姜黄
base0A: "F0C239" # yellow 缃色
base0B: "8AB361" # green 蟹壳青
base0C: "30DFF3" # aqua/cyan 湖蓝
base0D: "B0A4E3" # blue 雪青
base0E: "CCA4E3" # purple 丁香紫
base0F: "CA6924" # brown 琥珀
```
and Chinese encoding is gbk in python `open()` by default. So `encoding=utf8` is necessary.

## Use `git pull` instead of `shutil.rmtree`
