### PR TITLE
Added support for base24

### DIFF
--- a/pybase16_builder/builder.py
+++ b/pybase16_builder/builder.py
@@ -89,8 +89,10 @@ def format_scheme(scheme, slug):
     scheme["scheme-name"] = scheme.pop("scheme")
     scheme["scheme-author"] = scheme.pop("author")
     scheme["scheme-slug"] = slug
-    bases = ["base{:02X}".format(x) for x in range(0, 16)]
+    bases = ["base{:02X}".format(x) for x in range(0, 24)]
     for base in bases:
+        if base not in scheme:
+            continue
         scheme["{}-hex".format(base)] = scheme.pop(base)
         scheme["{}-hex-r".format(base)] = scheme["{}-hex".format(base)][0:2]
         scheme["{}-hex-g".format(base)] = scheme["{}-hex".format(base)][2:4]


### PR DESCRIPTION
This commit enables support for 24 colors (aka 'base24' https://github.com/Base24/base24/). It could be modified for 256 colors also. 

Unit tests are currently failing due to an issue with template-source repo (See PR https://github.com/chriskempson/base16-templates-source/pull/109 ), the workaround is to use my fork ( https://github.com/YoloClin/base16-templates-source ) for the time being, but I don't plan on maintaining my fork once it has been merged. 